### PR TITLE
Add atoms

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,14 +46,22 @@ lazy val root = (project in file("."))
 
 lazy val scalaClasses = (project in file("scala"))
   .settings(commonSettings)
+  .dependsOn(thrift)
   .settings(
     name := "story-model",
     description := "Story model",
     scroogeThriftSourceFolder in Compile := baseDirectory.value / "../thrift/src/main/thrift",
     scroogeThriftOutputFolder in Compile := sourceManaged.value,
+    scroogeThriftSources in Compile ++= {
+      (scroogeUnpackDeps in Compile).value.flatMap { dir => (dir ** "*.thrift").get }
+    },
     libraryDependencies ++= Seq(
         "org.apache.thrift" % "libthrift" % "0.9.3",
         "com.twitter" %% "scrooge-core" % "4.5.0"
+    ),
+    scroogeThriftDependencies in Compile ++= Seq(
+      "content-atom-model-thrift",
+      "content-entity-thrift"
     ),
     managedSourceDirectories in Compile += (scroogeThriftOutputFolder in Compile).value,
     // Include the Thrift file in the published jar
@@ -69,6 +77,9 @@ lazy val thrift = (project in file("thrift"))
     crossPaths := false,
     publishArtifact in packageDoc := false,
     publishArtifact in packageSrc := false,
+    libraryDependencies ++= Seq(
+      "com.gu" % "content-atom-model-thrift" % "2.4.36"
+    ),
     unmanagedResourceDirectories in Compile += { baseDirectory.value / "src/main/thrift" }
   )
 

--- a/thrift/src/main/thrift/story_model.thrift
+++ b/thrift/src/main/thrift/story_model.thrift
@@ -1,6 +1,8 @@
 namespace java com.gu.story.model.v1
 #@namespace scala com.gu.story.model.v1
 
+include "contentatom.thrift"
+
 enum ContentType {
     ARTICLE = 0,
     LIVEBLOG = 1,
@@ -39,4 +41,6 @@ struct Story {
         3: required string summary
 
         4: required list<StoryEvent> events
+
+        5: required list<contentatom.Atom> atoms
 }


### PR DESCRIPTION
A story will have a list of atoms associated with it. There are 2 obvious benefits here:
1. While writing an article, Editorial can quickly find all available atoms (e.g. explainers) for a given story.
2. Generate a 'story page' where readers can see special atoms assigned to this story

I'm not sure if events should also contain atoms, we can decide this later.