### PR TITLE
Remove scroogePublishThrift from scala project

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -63,9 +63,7 @@ lazy val scalaClasses = (project in file("scala"))
       "content-atom-model-thrift",
       "content-entity-thrift"
     ),
-    managedSourceDirectories in Compile += (scroogeThriftOutputFolder in Compile).value,
-    // Include the Thrift file in the published jar
-    scroogePublishThrift in Compile := true
+    managedSourceDirectories in Compile += (scroogeThriftOutputFolder in Compile).value
   )
 
 lazy val thrift = (project in file("thrift"))


### PR DESCRIPTION
This isn't required, and causes problems now that it has dependencies