### PR TITLE
fix (snyk): update default branch name in Snyk workflow

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -6,7 +6,7 @@ name: Snyk
 on:
   push:
     branches:
-      - main
+      - master
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## What does this change?
It was previously missed that the default branch of this repository is not `main`, this fixes the Snyk workflow so that it'll run as intended.