### PR TITLE
Fix synk high vulns

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -62,11 +62,14 @@ lazy val scalaClasses = (project in file("scala"))
     scroogePublishThrift in Compile := true,
     resolvers ++= Seq(Resolver.sonatypeRepo("public")),
     libraryDependencies ++= Seq(
-        "org.apache.thrift" % "libthrift" % "0.10.0",
+        "org.apache.thrift" % "libthrift" % "0.18.1",
         "com.twitter" %% "scrooge-core" % "19.3.0",
         "com.gu" % "content-entity-thrift" % "2.0.1",
         "com.gu" % "content-atom-model-thrift" % "3.0.2",
-        "com.gu" %% "content-atom-model" % "3.0.2"
+        "com.gu" %% "content-atom-model" % "3.0.2",
+        //adding annotation dependency to fix compilation error "Generated is not member of package javax.annotation"
+        //as recommended at https://github.com/bazelbuild/rules_scala/pull/1090 to comptaible for java 11 or any higher than java 8
+        "javax.annotation" % "javax.annotation-api" % "1.3.2",
     ),
   )
 


### PR DESCRIPTION
Fix Snyk vulnerabilities, High vulns are now down from 3 to 0 and total vulns down from 7 to 0.

Now:

<img width="1712" alt="image" src="https://user-images.githubusercontent.com/17780995/227275855-55c8af4a-dd2e-449e-a409-8c4bedca1256.png">
 

## How to test

At first, after project load sbt compilation was erroring so added annotation library as well to fix it.
After upgrades and fix, `sbt compile` is compiling fine.

We need to see how we can test this via deployment.
